### PR TITLE
Zugriffsschutz und Sichtbarkeit der Profildaten implementiert

### DIFF
--- a/backend/src/main/java/de/neighbourly/backend/controller/UserController.java
+++ b/backend/src/main/java/de/neighbourly/backend/controller/UserController.java
@@ -2,7 +2,6 @@ package de.neighbourly.backend.controller;
 
 import de.neighbourly.backend.dto.PasswordChangeRequest;
 import de.neighbourly.backend.dto.UserProfileDto;
-import de.neighbourly.backend.entity.User;
 import de.neighbourly.backend.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -22,17 +21,7 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserProfileDto> getMe(Authentication authentication) {
         String email = authentication.getName();
-        User user = userService.getCurrentUserByEmail(email);
-
-        UserProfileDto dto = new UserProfileDto(
-                user.getId(),
-                user.getUsername(),
-                user.getEmail()
-                //null,
-                //null
-        );
-
-        return ResponseEntity.ok(dto);
+        return ResponseEntity.ok(userService.getCurrentUserProfile(email));
     }
 
     @PutMapping("/me/change-password")

--- a/backend/src/main/java/de/neighbourly/backend/mapper/UserMapper.java
+++ b/backend/src/main/java/de/neighbourly/backend/mapper/UserMapper.java
@@ -1,0 +1,14 @@
+package de.neighbourly.backend.mapper;
+
+import de.neighbourly.backend.dto.UserProfileDto;
+import de.neighbourly.backend.entity.User;
+
+public class UserMapper {
+    public static UserProfileDto toDto(User user){
+        return new UserProfileDto (
+                user.getId(),
+                user.getUsername(),
+                user.getEmail()
+        );
+    }
+}

--- a/backend/src/main/java/de/neighbourly/backend/service/UserService.java
+++ b/backend/src/main/java/de/neighbourly/backend/service/UserService.java
@@ -2,8 +2,10 @@ package de.neighbourly.backend.service;
 
 import de.neighbourly.backend.dto.PasswordChangeRequest;
 import de.neighbourly.backend.dto.RegistrationRequest;
+import de.neighbourly.backend.dto.UserProfileDto;
 import de.neighbourly.backend.entity.User;
 import de.neighbourly.backend.entity.VerificationToken;
+import de.neighbourly.backend.mapper.UserMapper;
 import de.neighbourly.backend.repository.UserRepository;
 import de.neighbourly.backend.repository.VerificationTokenRepository;
 import org.springframework.http.HttpStatus;
@@ -82,10 +84,6 @@ public class UserService {
         tokenRepository.delete(verificationToken);
     }
 
-    public User getCurrentUserByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User nicht gefunden"));
-    }
 
     public void changePasswordByEmail(String email, PasswordChangeRequest request) {
         User user = userRepository.findByEmail(email)
@@ -114,5 +112,15 @@ public class UserService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User nicht gefunden"));
 
         userRepository.delete(user);
+    }
+
+    public User getCurrentUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User nicht gefunden"));
+    }
+
+    public UserProfileDto getCurrentUserProfile(String email) {
+        User user = getCurrentUserByEmail(email);
+        return UserMapper.toDto(user);
     }
 }


### PR DESCRIPTION
- Rückgabe nur erlaubter Felder im UserProfileDto (id, username, email)
- Entfernung sensibler Daten aus der API (z.B. password, verificationToken)
- Zugriff auf /api/users/me nur für authentifizierte Nutzer (JWT)

Refactoring:
- DTO-Mapping aus dem Controller in die Service-Schicht ausgelagert
- Einführung eines UserMappers zur klaren Trennung von Verantwortlichkeiten
- Controller vereinfacht (thin controller Ansatz) Zusätzlich zu den Anforderungen des Tickets ist eine kleine Code-Verbesserung (Refactoring) vorgenommen:

- Die Umwandlung von Entity zu DTO wurde aus dem Controller in die Service-Schicht ausgelagert
- Einführung eines UserMappers zur sauberen Trennung der Verantwortlichkeiten

Ziel:
- Dünnere Controller (keine Business-Logik)
- Bessere Wartbarkeit und klarere Struktur

Diese Änderung war nicht explizit Teil des Tickets, verbessert jedoch die Codequalität und entspricht gängigen Best Practices.