### PR TITLE
NEBO-223 prioritize urgent posts in post list

### DIFF
--- a/backend/src/main/java/de/neighbourly/backend/repository/PostRepository.java
+++ b/backend/src/main/java/de/neighbourly/backend/repository/PostRepository.java
@@ -10,5 +10,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByOrderByCreatedAtDesc();
 
-    List<Post> findByStatus(PostStatus status);
+    List<Post> findByStatusOrderByIsUrgentDescCreatedAtDesc(PostStatus status);
 }

--- a/backend/src/main/java/de/neighbourly/backend/service/PostService.java
+++ b/backend/src/main/java/de/neighbourly/backend/service/PostService.java
@@ -294,7 +294,11 @@ public class PostService {
     }
 
     public List<PostListItemResponseDto> getPostList() {
-        return postRepository.findByStatus(PostStatus.ACTIVE).stream().map(PostMapper::toListDto).toList();
+        return postRepository
+                .findByStatusOrderByIsUrgentDescCreatedAtDesc(PostStatus.ACTIVE)
+                .stream()
+                .map(PostMapper::toListDto)
+                .toList();
     }
 
     public List<MapPostDto> getMapPostMarker(Double lat, Double lng, Double radius) {


### PR DESCRIPTION
# NEBO-223 – Priorisierte Sortierung für dringliche Beiträge

## Änderungen

* Standardsortierung für `GET /api/posts` erweitert
* Dringende Beiträge werden zuerst ausgeliefert
* Sekundäre Sortierung erfolgt über `createdAt DESC`

## Technische Umsetzung

Repository-Methode angepasst:

* `findByStatusOrderByIsUrgentDescCreatedAtDesc(...)`

Service verwendet die neue Standardsortierung für aktive Beiträge.

## Test

* Anwendung erfolgreich gestartet
* `GET /api/posts` geprüft
* Verifiziert, dass ein älterer dringender Beitrag vor neueren nicht dringenden Beiträgen erscheint
