### PR TITLE
NEBO-224 implement urgentUntil expiration logic

### DIFF
--- a/backend/src/main/java/de/neighbourly/backend/mapper/PostMapper.java
+++ b/backend/src/main/java/de/neighbourly/backend/mapper/PostMapper.java
@@ -7,6 +7,7 @@ import de.neighbourly.backend.model.PostStatus;
 import de.neighbourly.backend.dto.PostDetailResponseDto;
 import java.util.List;
 import de.neighbourly.backend.dto.PostListItemResponseDto;
+import java.time.LocalDateTime;
 
 public class PostMapper {
 
@@ -36,7 +37,7 @@ public class PostMapper {
                 post.getDescription(),
                 post.getType().name(),
                 post.getPostMode().name(),
-                post.isUrgent(),
+                isEffectivelyUrgent(post),
                 post.getUrgentUntil(),
                 post.getCreatedAt(),
                 post.getStatus().name(),
@@ -52,7 +53,7 @@ public class PostMapper {
                 post.getDescription(),
                 post.getType().name(),
                 post.getPostMode().name(),
-                post.isUrgent(),
+                isEffectivelyUrgent(post),
                 post.getUrgentUntil(),
                 post.getCreatedAt(),
                 post.getStatus().name(),
@@ -73,7 +74,7 @@ public class PostMapper {
                 post.getDescription(),
                 post.getType().name(),
                 post.getPostMode().name(),
-                post.isUrgent(),
+                isEffectivelyUrgent(post),
                 post.getUrgentUntil(),
                 post.getCreatedAt(),
                 location,
@@ -84,4 +85,11 @@ public class PostMapper {
                 null
         );
     }
+
+
+    public static boolean isEffectivelyUrgent(Post post) {
+        return post.isUrgent()
+                && (post.getUrgentUntil() == null || post.getUrgentUntil().isAfter(LocalDateTime.now()));
+    }
+
 }

--- a/backend/src/main/java/de/neighbourly/backend/repository/PostRepository.java
+++ b/backend/src/main/java/de/neighbourly/backend/repository/PostRepository.java
@@ -10,5 +10,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByOrderByCreatedAtDesc();
 
-    List<Post> findByStatusOrderByIsUrgentDescCreatedAtDesc(PostStatus status);
+    List<Post> findByStatus(PostStatus status);
+
 }

--- a/backend/src/main/java/de/neighbourly/backend/service/PostService.java
+++ b/backend/src/main/java/de/neighbourly/backend/service/PostService.java
@@ -9,7 +9,7 @@ import de.neighbourly.backend.model.PostType;
 import de.neighbourly.backend.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
-
+import java.util.Comparator;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -294,9 +294,14 @@ public class PostService {
     }
 
     public List<PostListItemResponseDto> getPostList() {
-        return postRepository
-                .findByStatusOrderByIsUrgentDescCreatedAtDesc(PostStatus.ACTIVE)
+        return postRepository.findByStatus(PostStatus.ACTIVE)
                 .stream()
+                .sorted(
+                        Comparator
+                                .comparing(PostMapper::isEffectivelyUrgent)
+                                .reversed()
+                                .thenComparing(Post::getCreatedAt, Comparator.reverseOrder())
+                )
                 .map(PostMapper::toListDto)
                 .toList();
     }
@@ -316,7 +321,7 @@ public class PostService {
                             post.getTitle(),
                             location.getLatitude(),
                             location.getLongitude(),
-                            post.isUrgent(),
+                            PostMapper.isEffectivelyUrgent(post),
                             post.getPostMode().name(),
                             shortenDescription(post.getDescription()),
                             post.getCreatedAt()


### PR DESCRIPTION
## Changes

Implemented expiration handling for urgent posts.

### Business Rule

A post is considered urgent only if:

* `isUrgent = true`
* and `urgentUntil` is either not set (`null`) or lies in the future

Expired urgent posts are treated as non-urgent.

### Implementation

* Added effective urgency calculation in `PostMapper`
* Applied effective urgency to:

  * Post list responses
  * Post detail responses
  * Post creation responses
  * Map marker responses
* Updated post sorting to prioritize effectively urgent posts
* Replaced database sorting by raw `isUrgent` with application-side sorting based on effective urgency

### Manual Testing

Verified:

* `isUrgent=true` + future `urgentUntil` → urgent
* `isUrgent=true` + expired `urgentUntil` → not urgent
* Expired urgent posts are no longer prioritized in the list
* Map markers use the same urgency logic as the list
* Backend starts and runs successfully
