### PR TITLE
NEBO-225 add urgency expiration tests

### DIFF
--- a/backend/src/test/java/de/neighbourly/backend/mapper/PostMapperTest.java
+++ b/backend/src/test/java/de/neighbourly/backend/mapper/PostMapperTest.java
@@ -1,0 +1,47 @@
+package de.neighbourly.backend.mapper;
+
+import de.neighbourly.backend.entity.Post;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostMapperTest {
+
+    @Test
+    void shouldReturnTrueWhenUrgentAndNotExpired() {
+        Post post = new Post();
+        post.setUrgent(true);
+        post.setUrgentUntil(LocalDateTime.now().plusDays(1));
+
+        assertTrue(PostMapper.isEffectivelyUrgent(post));
+    }
+
+    @Test
+    void shouldReturnFalseWhenUrgentButExpired() {
+        Post post = new Post();
+        post.setUrgent(true);
+        post.setUrgentUntil(LocalDateTime.now().minusDays(1));
+
+        assertFalse(PostMapper.isEffectivelyUrgent(post));
+    }
+
+    @Test
+    void shouldReturnFalseWhenNotUrgent() {
+        Post post = new Post();
+        post.setUrgent(false);
+
+        assertFalse(PostMapper.isEffectivelyUrgent(post));
+    }
+
+
+    @Test
+    void shouldReturnTrueWhenUrgentAndNoExpirationDate() {
+        Post post = new Post();
+        post.setUrgent(true);
+        post.setUrgentUntil(null);
+
+        assertTrue(PostMapper.isEffectivelyUrgent(post));
+    }
+}


### PR DESCRIPTION
Für NEBO-225 habe ich zunächst die Logik aus NEBO-224 automatisiert abgesichert.

Abgedeckt sind aktuell die zentralen Fälle der Urgency-Logik:

✔ isUrgent = true + future urgentUntil → true
✔ isUrgent = true + expired urgentUntil → false
✔ isUrgent = true + urgentUntil = null → true
✔ isUrgent = false → false

Damit ist die in NEBO-224 eingeführte Ablauf-Logik durch automatisierte Tests abgesichert.

Ein zusätzlicher Test für die Sortierungslogik im PostService wäre grundsätzlich möglich, würde aber deutlich mehr Test-Setup (Mocking der Repositories und Service-Abhängigkeiten) erfordern. Da dies über die eigentliche Business-Regel aus NEBO-224 hinausgeht, würde ich das bei Bedarf als separaten Schritt bzw. als eigene Erweiterung umsetzen.
