### PR TITLE
NEBO-395 implement logout button

### DIFF
--- a/frontend/frontend/src/app/navbar/navbar.css
+++ b/frontend/frontend/src/app/navbar/navbar.css
@@ -341,3 +341,25 @@
     height: 38px;
   }
 }
+
+.logout-btn {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  color: #ffffff;
+  background: #4e5d69;
+  border: 0;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 800;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.logout-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--navbar-hover-shadow);
+}

--- a/frontend/frontend/src/app/navbar/navbar.html
+++ b/frontend/frontend/src/app/navbar/navbar.html
@@ -34,6 +34,17 @@
       >
         <span class="profile-icon" aria-hidden="true"></span>
       </a>
+      @if (isLoggedIn()) {
+        <button
+          type="button"
+          class="logout-btn"
+          (click)="logout()"
+          aria-label="Abmelden"
+        >
+          Logout
+        </button>
+      }
     </div>
   </div>
 </nav>
+

--- a/frontend/frontend/src/app/navbar/navbar.ts
+++ b/frontend/frontend/src/app/navbar/navbar.ts
@@ -29,4 +29,12 @@ export class Navbar {
   accountAriaLabel() {
     return this.authService.isLoggedIn() ? 'Zum Profil gehen' : 'Zur Anmeldung gehen';
   }
+
+  isLoggedIn() {
+    return this.authService.isLoggedIn();
+  }
+
+  logout() {
+    this.authService.logout();
+  }
 }


### PR DESCRIPTION
NEBO-395 – Logout-Button implementieren

Änderungen

* Logout-Button in der Navigation hinzugefügt
* Logout mit bestehendem AuthService verbunden
* JWT-Token wird beim Logout aus dem LocalStorage entfernt
* Weiterleitung zur Login-Seite nach Logout
* Sichtbarkeit des Buttons nur für eingeloggte Benutzer

Getestet

* Login erfolgreich
* Logout-Button wird angezeigt
* Logout entfernt den Token aus dem LocalStorage
* Weiterleitung auf /auth funktioniert
* Geschützte Seiten sind nach Logout nicht mehr erreichbar
