### PR TITLE
NEBO-397 validate city and postal code combination

### DIFF
--- a/backend/src/main/java/de/neighbourly/backend/dto/CreatePostLocationDto.java
+++ b/backend/src/main/java/de/neighbourly/backend/dto/CreatePostLocationDto.java
@@ -1,6 +1,7 @@
 package de.neighbourly.backend.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,10 +14,18 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CreatePostLocationDto {
 
+    @NotBlank(message = "city is required")
+    private String city;
+
+    @NotBlank(message = "postalCode is required")
+    private String postalCode;
+
+    private String address;
+
     @NotNull(message = "lat is required")
     private Double lat;
 
-    @NotNull(message = "lng ist required")
+    @NotNull(message = "lng is required")
     private Double lng;
 
     @NotNull(message = "precision is required")

--- a/backend/src/main/java/de/neighbourly/backend/dto/GeoCoordinatesResponseDto.java
+++ b/backend/src/main/java/de/neighbourly/backend/dto/GeoCoordinatesResponseDto.java
@@ -1,4 +1,8 @@
 package de.neighbourly.backend.dto;
 
-public record GeoCoordinatesResponseDto(double latitude, double longitude) {
+public record GeoCoordinatesResponseDto(
+        double latitude,
+        double longitude,
+        String city
+) {
 }

--- a/backend/src/main/java/de/neighbourly/backend/dto/LocationDto.java
+++ b/backend/src/main/java/de/neighbourly/backend/dto/LocationDto.java
@@ -9,7 +9,8 @@ import lombok.Setter;
 @AllArgsConstructor
 public class LocationDto {
     private String city;
-    private String district;
+    private String postalCode;
+    private String address;
     private Double latitude;
     private Double longitude;
 }

--- a/backend/src/main/java/de/neighbourly/backend/entity/PostLocation.java
+++ b/backend/src/main/java/de/neighbourly/backend/entity/PostLocation.java
@@ -15,16 +15,18 @@ public class PostLocation {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;
-
         private String city;
 
-        private String district;
+        private String postalCode;
+
+        private String address;
 
         private Double latitude;
 
         private Double longitude;
 
         private String precision;
+
 
         @Column(name = "radius_m")
         private Integer radiusM;

--- a/backend/src/main/java/de/neighbourly/backend/service/GeoService.java
+++ b/backend/src/main/java/de/neighbourly/backend/service/GeoService.java
@@ -24,6 +24,7 @@ public class GeoService {
                 .queryParam("countrycodes", "de")
                 .queryParam("format", "json")
                 .queryParam("limit", 1)
+                .queryParam("addressdetails", 1)
                 .toUriString();
 
         HttpHeaders headers = new HttpHeaders();
@@ -46,10 +47,25 @@ public class GeoService {
         }
 
         Map<String, Object> firstResult = body.get(0);
-
         double latitude = Double.parseDouble(firstResult.get("lat").toString());
         double longitude = Double.parseDouble(firstResult.get("lon").toString());
 
-        return new GeoCoordinatesResponseDto(latitude, longitude);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> address = (Map<String, Object>) firstResult.get("address");
+
+        String city = address.getOrDefault("city",
+                address.getOrDefault("town",
+                        address.getOrDefault("village",
+                                address.getOrDefault("municipality", "")
+                        )
+                )
+        ).toString();
+
+        if (city.isBlank()) {
+            city = firstResult.get("name").toString();
+        }
+
+        return new GeoCoordinatesResponseDto(latitude, longitude, city);
     }
 }
+

--- a/backend/src/main/java/de/neighbourly/backend/service/PostService.java
+++ b/backend/src/main/java/de/neighbourly/backend/service/PostService.java
@@ -27,6 +27,7 @@ public class PostService {
     private final PostImageRepository postImageRepository;
     private final ObjectMapper objectMapper;
     private final HousingDetailRepository housingDetailRepository;
+    private final GeoService geoService;
 
     public PostService(
             PostRepository postRepository,
@@ -38,7 +39,9 @@ public class PostService {
             PostTagRepository postTagRepository,
             PostImageRepository postImageRepository,
             ObjectMapper objectMapper,
-            HousingDetailRepository housingDetailRepository
+            HousingDetailRepository housingDetailRepository,
+            GeoService geoService
+
     ) {
         this.postRepository = postRepository;
         this.userRepository = userRepository;
@@ -50,6 +53,8 @@ public class PostService {
         this.postImageRepository = postImageRepository;
         this.objectMapper = objectMapper;
         this.housingDetailRepository = housingDetailRepository;
+
+        this.geoService = geoService;
     }
 
     public PostResponseDto createPost(CreatePostRequest request, String email) {
@@ -57,8 +62,9 @@ public class PostService {
 
         validateDetailsMatchPostType(request);
         validateTypeSpecificDetails(request);
+        validateLocation(request);
 
-        if (!request.getIsUrgent() && request.getUrgentUntil() != null) {
+        if (!request.getIsUrgent()  && request.getUrgentUntil() != null) {
             throw new IllegalArgumentException("urgentUntil is only allowed when isUrgent is true");
         }
 
@@ -241,7 +247,8 @@ public class PostService {
     private LocationDto mapLocation(PostLocation location) {
         return new LocationDto(
                 location.getCity(),
-                location.getDistrict(),
+                location.getPostalCode(),
+                location.getAddress(),
                 location.getLatitude(),
                 location.getLongitude()
         );
@@ -370,6 +377,9 @@ public class PostService {
 
         PostLocation location = new PostLocation();
         location.setPost(savedPost);
+        location.setCity(dto.getCity());
+        location.setPostalCode(dto.getPostalCode());
+        location.setAddress(dto.getAddress());
         location.setLatitude(dto.getLat());
         location.setLongitude(dto.getLng());
         location.setPrecision(dto.getPrecision());
@@ -401,6 +411,23 @@ public class PostService {
 
         if (request.getType() == PostType.HOUSING && !(details instanceof HousingDetailsDto)) {
             throw new IllegalArgumentException("details do not match post type HOUSING");
+        }
+    }
+
+    private void validateLocation(CreatePostRequest request) {
+        if (request.getLocation() == null) {
+            return;
+        }
+
+        CreatePostLocationDto location = request.getLocation();
+
+        GeoCoordinatesResponseDto geoResponse =
+                geoService.getCoordinatesByPlz(location.getPostalCode());
+
+        if (!geoResponse.city().equalsIgnoreCase(location.getCity().trim())) {
+            throw new IllegalArgumentException(
+                    "Die eingegebene Postleitzahl passt nicht zur angegebenen Stadt."
+            );
         }
     }
 }

--- a/backend/src/main/resources/db/migration/V16__update_post_locations_for_city_validation.sql
+++ b/backend/src/main/resources/db/migration/V16__update_post_locations_for_city_validation.sql
@@ -1,0 +1,8 @@
+ALTER TABLE post_locations
+    ADD COLUMN postal_code VARCHAR(255);
+
+ALTER TABLE post_locations
+    ADD COLUMN address VARCHAR(500);
+
+ALTER TABLE post_locations
+    DROP COLUMN district;

--- a/frontend/frontend/src/app/create-post/create-post.css
+++ b/frontend/frontend/src/app/create-post/create-post.css
@@ -199,3 +199,12 @@
   height: 100%;
 }
 
+.error-message {
+  color: #b42318;
+  background: #fef3f2;
+  border: 1px solid #fecdca;
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-top: 16px;
+  font-weight: 500;
+}

--- a/frontend/frontend/src/app/create-post/create-post.ts
+++ b/frontend/frontend/src/app/create-post/create-post.ts
@@ -185,9 +185,9 @@ export class CreatePost implements OnInit {
           this.postModel = {
             ...this.postModel,
             resolvedLocation: {
-              city: value.city.trim(),
-              postalCode: value.postalCode.trim(),
-              address: value.address.trim() || null,
+              city: this.postModel.city.trim(),
+              postalCode: this.postModel.postalCode.trim(),
+              address: this.postModel.address.trim() || null,
               lat: coordinates.latitude,
               lng: coordinates.longitude,
               precision: 'POSTAL_CODE',

--- a/frontend/frontend/src/app/create-post/create-post.ts
+++ b/frontend/frontend/src/app/create-post/create-post.ts
@@ -197,9 +197,7 @@ export class CreatePost implements OnInit {
 
           const payload = this.createPayload();
           this.createPost(payload);
-          setTimeout(() => {
-            this.router.navigate(['/map']);
-          }, 1500);
+
 
         },
         error: (err) => {
@@ -215,9 +213,6 @@ export class CreatePost implements OnInit {
 
     const payload = this.createPayload();
     this.createPost(payload);
-    setTimeout(() => {
-      this.router.navigate(['/posts']);
-    }, 1500);
 
   }
 
@@ -229,6 +224,10 @@ export class CreatePost implements OnInit {
         this.savedPayload.set(payload);
         this.successMessage.set('Beitrag wurde erfolgreich erstellt.');
         this.isLoading.set(false);
+
+        setTimeout(() => {
+          this.router.navigate(['/map']);
+        }, 1500);
       },
       error: (err) => {
         console.error(err);

--- a/frontend/frontend/src/app/create-post/create-post.ts
+++ b/frontend/frontend/src/app/create-post/create-post.ts
@@ -151,6 +151,9 @@ export class CreatePost {
           this.postModel.update((currentValue) => ({
             ...currentValue,
             resolvedLocation: {
+              city: value.city.trim(),
+              postalCode: value.postalCode.trim(),
+              address: value.address.trim() || null,
               lat: coordinates.latitude,
               lng: coordinates.longitude,
               precision: 'POSTAL_CODE',

--- a/frontend/frontend/src/app/mocks/post-detail.mock.ts
+++ b/frontend/frontend/src/app/mocks/post-detail.mock.ts
@@ -1,38 +1,39 @@
 import {PostDetailResponse} from '../models/post-detail.model';
 
 export const postDetailMock: PostDetailResponse = {
-    id: 1,
-    title: 'Need help repairing my bike',
-    description: 'My bike chain is broken and I need help fixing it.',
-    type: 'SKILL',
-    isUrgent: true,
-    urgentUntil: '2026-05-10T18:00:00',
-    createdAt: '2026-05-07T10:30:00',
-    location: {
-        city: 'Berlin',
-        district: 'Mitte',
-        latitude: 52.52,
-        longitude: 13.405,
+  id: 1,
+  title: 'Need help repairing my bike',
+  description: 'My bike chain is broken and I need help fixing it.',
+  type: 'SKILL',
+  isUrgent: true,
+  urgentUntil: '2026-05-10T18:00:00',
+  createdAt: '2026-05-07T10:30:00',
+  location: {
+    city: 'Berlin',
+    postalCode: '10115',
+    address: 'Musterstraße 1',
+    latitude: 52.52,
+    longitude: 13.405,
+  },
+  tags: ['bike', 'repair', 'help'],
+  images: [
+    {
+      id: 1,
+      url: 'https://picsum.photos/id/237/200/300',
+      altText: 'Broken bike chain',
     },
-    tags: ['bike', 'repair', 'help'],
-    images: [
-        {
-            id: 1,
-            url: 'https://picsum.photos/id/237/200/300',
-            altText: 'Broken bike chain',
-        },
-      {
-        id: 2,
-        url: 'https://picsum.photos/id/238/200/300',
-        altText: 'Broken bike chain 2',
-      },
-    ],
-    details: {
-        requestedHelpType: 'REPAIR',
-        preferredTime: 'Evening',
+    {
+      id: 2,
+      url: 'https://picsum.photos/id/238/200/300',
+      altText: 'Broken bike chain 2',
     },
+  ],
+  details: {
+    requestedHelpType: 'REPAIR',
+    preferredTime: 'Evening',
+  },
 
-    reportSummary: {
-        reportCount: 0,
-    },
+  reportSummary: {
+    reportCount: 0,
+  },
 };

--- a/frontend/frontend/src/app/models/post-detail.model.ts
+++ b/frontend/frontend/src/app/models/post-detail.model.ts
@@ -18,7 +18,8 @@ export interface PostDetailResponse {
 
 export interface LocationDto {
   city: string;
-  district: string;
+  postalCode?: string | null;
+  address?: string | null;
   latitude: number;
   longitude: number;
 }

--- a/frontend/frontend/src/app/models/post.model.ts
+++ b/frontend/frontend/src/app/models/post.model.ts
@@ -4,13 +4,16 @@ export type PostStatus = 'ACTIVE' | 'ARCHIVED' | string;
 
 export interface LocationDto {
   city: string;
-  district?: string | null;
+  postalCode?: string | null;
   address?: string | null;
   latitude?: number | null;
   longitude?: number | null;
 }
 
 export interface CreatePostLocationDto {
+  city: string;
+  postalCode: string;
+  address?: string | null;
   lat: number;
   lng: number;
   precision: string;

--- a/frontend/frontend/src/app/post-detail/post-detail.ts
+++ b/frontend/frontend/src/app/post-detail/post-detail.ts
@@ -93,7 +93,12 @@ export class PostDetailComponent implements OnInit, OnDestroy {
       return 'Noch kein Standort hinterlegt';
     }
 
-    const parts = [location.district, location.city].filter(Boolean);
+    const parts = [
+      location.address,
+      location.postalCode,
+      location.city,
+    ].filter(Boolean);
+
     return parts.length > 0 ? parts.join(', ') : 'Standort ohne Ortsnamen';
   }
 


### PR DESCRIPTION
This PR introduces validation for city and postal code combinations when creating posts.

### Changes

* Added postal code validation using the OpenStreetMap Nominatim API.
* Added `postalCode` and `address` to post locations.
* Removed the obsolete `district` field.
* Updated backend DTOs, entities and services.
* Added Flyway migration `V16__update_post_locations_for_city_validation.sql`.
* Updated frontend models and create-post flow.
* Added user-facing validation error for invalid city/postal-code combinations.

### Validation Examples

✅ München + 80331

✅ Hamburg + 20095

✅ Bremen + 28207

❌ Berlin + 80331

Error message:
`Die eingegebene Postleitzahl passt nicht zur angegebenen Stadt.`

### Testing

* Verified post creation through API.
* Verified post creation through UI.
* Verified invalid combinations are rejected.
* Verified location data is persisted correctly in PostgreSQL.
* Verified backend startup and Flyway migration.
* Verified frontend build (`npm run build`).
