### PR TITLE
NEBO-231 handle loading error and empty states for urgent posts

### DIFF
--- a/frontend/frontend/src/app/map-overlay/map-overlay.css
+++ b/frontend/frontend/src/app/map-overlay/map-overlay.css
@@ -125,3 +125,14 @@
   height: 100%;
   overflow-y: auto;
 }
+
+.overlay-state {
+  padding: 1rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.overlay-state--error {
+  color: var(--red-color);
+}

--- a/frontend/frontend/src/app/map-overlay/map-overlay.html
+++ b/frontend/frontend/src/app/map-overlay/map-overlay.html
@@ -7,16 +7,21 @@
 
   @if (isOpen) {
     <div class="overlay-content">
-      <!-- später Inhalt -->
-
-      @for (post of posts(); track post.id) {
-        <app-sidebar-entry
-          [post]="post"
-          [class.selected]="selectedPost()?.id === post.id"
-          (click)="postService.selectMapPost(post)"
-          (selectPost)="selectPost($event)"
-          [selected]="selectedPost()?.id === post.id"
-        ></app-sidebar-entry>
-      }</div>
+      @if (state() === 'loading') {
+        <p class="overlay-state">Beiträge werden geladen...</p>
+      } @else if (state() === 'error') {
+        <p class="overlay-state overlay-state--error">{{ errorMessage() }}</p>
+      } @else if (state() === 'empty') {
+        <p class="overlay-state">Keine Beiträge in diesem Kartenausschnitt.</p>
+      } @else {
+        @for (post of posts(); track post.id) {
+          <app-sidebar-entry
+            [post]="post"
+            [selected]="selectedPost()?.id === post.id"
+            (selectPost)="selectPost($event)"
+          ></app-sidebar-entry>
+        }
+      }
+    </div>
   }
 </aside>

--- a/frontend/frontend/src/app/map-overlay/map-overlay.ts
+++ b/frontend/frontend/src/app/map-overlay/map-overlay.ts
@@ -19,6 +19,8 @@ export class MapOverlayComponent {
 
   readonly posts = this.postService.mapPosts;
   readonly selectedPost = this.postService.selectedMapPost;
+  readonly state = this.postService.mapPostsState;
+  readonly errorMessage = this.postService.mapPostsError;
 
   selectPost(post: MapPostMarker): void {
     if (!this.isOpen) {

--- a/frontend/frontend/src/app/services/posts.service.ts
+++ b/frontend/frontend/src/app/services/posts.service.ts
@@ -10,6 +10,8 @@ import {UpdatePostRequest} from '../models/update-post-request.model';
 import {PostDetailResponse} from '../models/post-detail.model';
 import {postDetailMock} from '../mocks/post-detail.mock';
 
+type MapPostsState = 'loading' | 'empty' | 'error' | 'ready';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -22,6 +24,9 @@ export class PostsService {
 
   readonly mapPosts = signal<MapPostMarker[]>([]);
   readonly selectedMapPost = signal<MapPostMarker | null>(null);
+  readonly mapPostsState = signal<MapPostsState>('loading');
+  readonly mapPostsError = signal('');
+
 
   getPosts(): Observable<PostResponse[]> {
     if (this.useMockPosts) {
@@ -36,8 +41,12 @@ export class PostsService {
   }
 
   loadMapPostMarkers(lat: number, lng: number, radius: number): void {
+    this.mapPostsState.set('loading');
+    this.mapPostsError.set('');
+
     if (this.useMockPosts) {
       this.mapPosts.set(MOCK_MAP_POST_MARKERS);
+      this.mapPostsState.set(MOCK_MAP_POST_MARKERS.length === 0 ? 'empty' : 'ready');
       return;
     }
 
@@ -50,8 +59,23 @@ export class PostsService {
 
     this.http
       .get<MapPostMarker[]>(`${this.apiUrl}/marker`, { params })
-      .subscribe((posts) => {
-        this.mapPosts.set(posts);
+      .subscribe({
+        next: (posts) => {
+          this.mapPosts.set(posts);
+          this.mapPostsState.set(posts.length === 0 ? 'empty' : 'ready');
+
+          const selectedPost = this.selectedMapPost();
+
+          if (selectedPost && !posts.some((post) => post.id === selectedPost.id)) {
+            this.selectedMapPost.set(null);
+          }
+        },
+        error: () => {
+          this.mapPosts.set([]);
+          this.selectedMapPost.set(null);
+          this.mapPostsError.set('Beiträge auf der Karte konnten nicht geladen werden.');
+          this.mapPostsState.set('error');
+        },
       });
   }
 


### PR DESCRIPTION
## Summary

Implemented stable state handling for urgent post presentation in the map overlay.

### Changes

* Added loading state for map posts
* Added empty state when no posts are available in the current map area
* Added error state for failed marker loading requests
* Added error message handling in `PostsService`
* Improved map overlay UI feedback for loading, empty and error scenarios

### Testing

* Verified urgent posts remain highlighted after page refresh
* Verified empty state is displayed when no posts are available
* Verified loading state is shown while posts are fetched
* Verified error state is shown when marker loading fails
* Verified urgent markers are displayed correctly on the map

### Acceptance Criteria

* UI remains stable during loading and error states ✅
* No incorrect or inconsistent urgent highlighting ✅
* Empty states are handled properly ✅
