### PR TITLE
Improve marker precision for full addresses

### DIFF
--- a/backend/src/main/java/de/neighbourly/backend/controller/GeoController.java
+++ b/backend/src/main/java/de/neighbourly/backend/controller/GeoController.java
@@ -14,7 +14,11 @@ public class GeoController {
     private final GeoService geoService;
 
     @GetMapping("/coordinates")
-    public ResponseEntity<GeoCoordinatesResponseDto> getCoordinates(@RequestParam String plz) {
-        return ResponseEntity.ok(geoService.getCoordinatesByPlz(plz));
+    public ResponseEntity<GeoCoordinatesResponseDto> getCoordinates(
+            @RequestParam String plz,
+            @RequestParam String city,
+            @RequestParam(required = false) String address
+    ) {
+        return ResponseEntity.ok(geoService.getCoordinates(plz, city, address));
     }
 }

--- a/backend/src/main/java/de/neighbourly/backend/service/GeoService.java
+++ b/backend/src/main/java/de/neighbourly/backend/service/GeoService.java
@@ -6,6 +6,7 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,81 @@ public class GeoService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
+    public GeoCoordinatesResponseDto getCoordinates(String plz, String city, String address) {
+        if (address != null && !address.isBlank()) {
+            return getCoordinatesByFullAddress(plz, city, address);
+        }
+
+        return getCoordinatesByPlz(plz);
+    }
+
+    private GeoCoordinatesResponseDto getCoordinatesByFullAddress(String plz, String city, String address) {
+
+        String originalStreet = address.trim();
+
+        String normalizedStreet = originalStreet
+                .replace("ß", "ss")
+                .replace("Straße", "Strasse")
+                .replace("straße", "strasse");
+
+        List<String> streets = List.of(originalStreet, normalizedStreet);
+
+        for (String street : streets) {
+            String url = UriComponentsBuilder
+                    .fromUriString(NOMINATIM_URL)
+                    .queryParam("street", street)
+                    .queryParam("postalcode", plz.trim())
+                    .queryParam("city", city.trim())
+                    .queryParam("country", "Germany")
+                    .queryParam("countrycodes", "de")
+                    .queryParam("format", "json")
+                    .queryParam("limit", 1)
+                    .queryParam("addressdetails", 1)
+                    .toUriString();
+
+            List<Map<String, Object>> body = fetchGeoResults(url);
+
+            if (body != null && !body.isEmpty()) {
+                Map<String, Object> firstResult = body.get(0);
+
+                double latitude = Double.parseDouble(firstResult.get("lat").toString());
+                double longitude = Double.parseDouble(firstResult.get("lon").toString());
+
+                return new GeoCoordinatesResponseDto(latitude, longitude, city.trim());
+            }
+        }
+
+        List<String> queries = List.of(
+                originalStreet + ", " + plz.trim() + " " + city.trim() + ", Deutschland",
+                normalizedStreet + ", " + plz.trim() + " " + city.trim() + ", Deutschland",
+                city.trim() + " " + originalStreet,
+                city.trim() + " " + normalizedStreet
+        );
+
+        for (String query : queries) {
+            String url = UriComponentsBuilder
+                    .fromUriString(NOMINATIM_URL)
+                    .queryParam("q", query)
+                    .queryParam("countrycodes", "de")
+                    .queryParam("format", "json")
+                    .queryParam("limit", 1)
+                    .queryParam("addressdetails", 1)
+                    .toUriString();
+
+            List<Map<String, Object>> body = fetchGeoResults(url);
+
+            if (body != null && !body.isEmpty()) {
+                Map<String, Object> firstResult = body.get(0);
+
+                double latitude = Double.parseDouble(firstResult.get("lat").toString());
+                double longitude = Double.parseDouble(firstResult.get("lon").toString());
+
+                return new GeoCoordinatesResponseDto(latitude, longitude, city.trim());
+            }
+        }
+
+        throw new IllegalArgumentException("Die eingegebene Adresse konnte nicht gefunden werden.");
+    }
     public GeoCoordinatesResponseDto getCoordinatesByPlz(String plz) {
         String url = UriComponentsBuilder
                 .fromUriString(NOMINATIM_URL)
@@ -27,20 +103,7 @@ public class GeoService {
                 .queryParam("addressdetails", 1)
                 .toUriString();
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("User-Agent", "Neighbourly/1.0");
-
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
-
-        ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                entity,
-                new ParameterizedTypeReference<>() {
-                }
-        );
-
-        List<Map<String, Object>> body = response.getBody();
+        List<Map<String, Object>> body = fetchGeoResults(url);
 
         if (body == null || body.isEmpty()) {
             throw new IllegalArgumentException("Ungültige Postleitzahl.");
@@ -67,5 +130,32 @@ public class GeoService {
 
         return new GeoCoordinatesResponseDto(latitude, longitude, city);
     }
+
+
+    private List<Map<String, Object>> fetchGeoResults(String url) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("User-Agent", "Neighbourly/1.0");
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    new ParameterizedTypeReference<>() {
+                    }
+            );
+
+            return response.getBody();
+        } catch (HttpClientErrorException.TooManyRequests ex) {
+            throw new IllegalArgumentException(
+                    "Der Geocoding-Dienst ist aktuell ausgelastet. Bitte versuche es gleich erneut."
+            );
+        }
+    }
+
+
+
 }
 

--- a/backend/src/main/java/de/neighbourly/backend/service/PostService.java
+++ b/backend/src/main/java/de/neighbourly/backend/service/PostService.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -319,15 +320,15 @@ public class PostService {
         );
     }
 
-   private PostImageDto mapImage(PostImage image) {
-    return new PostImageDto(
-            image.getId(),
-            image.getUrl(),
-            image.getAltText(),
-            image.getOrderIndex(),
-            image.getCreatedAt()
-    );
-}
+    private PostImageDto mapImage(PostImage image) {
+        return new PostImageDto(
+                image.getId(),
+                image.getUrl(),
+                image.getAltText(),
+                image.getOrderIndex(),
+                image.getCreatedAt()
+        );
+    }
 
     @Transactional
     public PostImageDto uploadPostImage(Long postId, MultipartFile file, String altText, Long userId) {
@@ -535,12 +536,15 @@ public class PostService {
         CreatePostLocationDto dto = request.getLocation();
         dto.validate();
 
-        Double latitude = dto.getLat();
-        Double longitude = dto.getLng();
+        GeoCoordinatesResponseDto coordinates =
+                geoService.getCoordinates(dto.getPostalCode(), dto.getCity(), dto.getAddress());
+
+        Double latitude = coordinates.latitude();
+        Double longitude = coordinates.longitude();
 
         if (dto.getPrecision() == PrecisionType.RADIUS) {
             LocationMaskingUtil.MaskedCoordinates maskedCoordinates =
-                    LocationMaskingUtil.maskedCoordinates(dto.getLat(), dto.getLng(), dto.getRadiusM());
+                    LocationMaskingUtil.maskedCoordinates(latitude, longitude, dto.getRadiusM());
 
             latitude = maskedCoordinates.lat();
             longitude = maskedCoordinates.lng();
@@ -595,7 +599,11 @@ public class PostService {
         GeoCoordinatesResponseDto geoResponse =
                 geoService.getCoordinatesByPlz(location.getPostalCode());
 
-        if (!geoResponse.city().equalsIgnoreCase(location.getCity().trim())) {
+        String returnedCity = geoResponse.city().toLowerCase();
+        String inputCity = location.getCity().trim().toLowerCase();
+
+
+        if (!returnedCity.contains(inputCity) && !inputCity.contains(returnedCity)) {
             throw new IllegalArgumentException(
                     "Die eingegebene Postleitzahl passt nicht zur angegebenen Stadt."
             );

--- a/frontend/frontend/src/app/create-post/create-post.html
+++ b/frontend/frontend/src/app/create-post/create-post.html
@@ -254,7 +254,6 @@
 
         <label class="field span-two">
           <span>Adresse (optional)</span>
-          <p>Wenn eine genaue Adresse eingegeben wird, wird diese auch in dem Beitrag und auf der Map an der genauen Adresse angezeigt.</p>
           <input
             type="text"
             name="address"

--- a/frontend/frontend/src/app/create-post/create-post.ts
+++ b/frontend/frontend/src/app/create-post/create-post.ts
@@ -185,7 +185,11 @@ export class CreatePost implements OnInit {
 
       this.isLoading.set(true);
 
-      this.geoService.getCoordinatesByPlz(this.postModel.postalCode).subscribe({
+    this.geoService.getCoordinates(
+      this.postModel.postalCode,
+      this.postModel.city,
+      this.postModel.address
+    ).subscribe({
         next: (coordinates) => {
           console.log('GEO OK', coordinates);
 

--- a/frontend/frontend/src/app/services/geo.service.ts
+++ b/frontend/frontend/src/app/services/geo.service.ts
@@ -10,9 +10,20 @@ export class GeoService {
   private readonly http = inject(HttpClient);
   private readonly apiUrl = '/api/geo/coordinates';
 
-  getCoordinatesByPlz(plz: string): Observable<GeoCoordinatesResponse> {
-    const params = new HttpParams().set('plz', plz.trim());
+  getCoordinates(
+    plz: string,
+    city: string,
+    address?: string | null
+  ): Observable<GeoCoordinatesResponse> {
 
-    return this.http.get<GeoCoordinatesResponse>(this.apiUrl, {params});
+    let params = new HttpParams()
+      .set('plz', plz.trim())
+      .set('city', city.trim());
+
+    if (address?.trim()) {
+      params = params.set('address', address.trim());
+    }
+
+    return this.http.get<GeoCoordinatesResponse>(this.apiUrl, { params });
   }
 }


### PR DESCRIPTION
## Summary

Improved geocoding behaviour when creating posts with an address.

### Changes

* Added support for address-based geocoding in addition to postal-code-based geocoding.
* If an address is provided, the backend now attempts to resolve coordinates using the full address.
* Added multiple address lookup strategies and normalization for common German street formats (e.g. Straße / Strasse).
* Improved city validation for postal code checks.
* Added user-friendly error handling for geocoding failures and rate limiting responses from the external geocoding service.
* Updated frontend geo requests to send city and optional address information.

### Notes

* City and postal code remain required fields.
* Address remains optional.
* If address geocoding succeeds, markers can be positioned more accurately than before.
* Exact address resolution depends on the external Nominatim service and may vary depending on the provided address.
